### PR TITLE
Allow to specify packages to include/exclude.

### DIFF
--- a/src/main/java/de/andrena/tools/nopackagecycles/NoPackageCyclesRule.java
+++ b/src/main/java/de/andrena/tools/nopackagecycles/NoPackageCyclesRule.java
@@ -4,9 +4,11 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 import jdepend.framework.JDepend;
 import jdepend.framework.JavaPackage;
+import jdepend.framework.PackageFilter;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRule;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
@@ -16,6 +18,8 @@ import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluatio
 public class NoPackageCyclesRule implements EnforcerRule {
 
 	private boolean includeTests = true;
+	private List<String> includedPackages = new ArrayList<>();
+	private List<String> excludedPackages = new ArrayList<>();
 
 	public void execute(EnforcerRuleHelper helper) throws EnforcerRuleException {
 		try {
@@ -49,7 +53,9 @@ public class NoPackageCyclesRule implements EnforcerRule {
 	}
 
 	protected JDepend createJDepend() {
-		return new JDepend();
+		return new JDepend(PackageFilter.all()
+				.including(includedPackages)
+				.excluding(excludedPackages));
 	}
 
 	private String getPackageCycles(JDepend jdepend) {
@@ -72,4 +78,13 @@ public class NoPackageCyclesRule implements EnforcerRule {
 	public void setIncludeTests(boolean includeTests) {
 		this.includeTests = includeTests;
 	}
+
+	public void setIncludedPackages(List<String> includedPackages) {
+		this.includedPackages = includedPackages;
+	}
+
+	public void setExcludedPackages(List<String> excludedPackages) {
+		this.excludedPackages = excludedPackages;
+	}
+
 }

--- a/src/main/java/de/andrena/tools/nopackagecycles/NoPackageCyclesRule.java
+++ b/src/main/java/de/andrena/tools/nopackagecycles/NoPackageCyclesRule.java
@@ -35,14 +35,14 @@ public class NoPackageCyclesRule implements EnforcerRule {
 			throws ExpressionEvaluationException, IOException, EnforcerRuleException {
 		DirectoriesWithClasses directories = new DirectoriesWithClasses(helper, includeTests);
 		if (directories.directoriesWithClassesFound()) {
-			executePackageCycleCheck(directories);
+			executePackageCycleCheck(helper, directories);
 		} else {
 			helper.getLog().info("No directories with classes to check for cycles found.");
 		}
 	}
 
-	private void executePackageCycleCheck(Iterable<File> directories) throws IOException, EnforcerRuleException {
-		JDepend jdepend = createJDepend();
+	private void executePackageCycleCheck(EnforcerRuleHelper helper, Iterable<File> directories) throws IOException, EnforcerRuleException {
+		JDepend jdepend = createJDepend(helper);
 		for (File directory : directories) {
 			jdepend.addDirectory(directory.getAbsolutePath());
 		}
@@ -52,7 +52,13 @@ public class NoPackageCyclesRule implements EnforcerRule {
 		}
 	}
 
-	protected JDepend createJDepend() {
+	protected JDepend createJDepend(EnforcerRuleHelper helper) {
+		if (!includedPackages.isEmpty()) {
+			helper.getLog().warn("Package cycles rule check is restricted to check only these packages: " + includedPackages);
+		}
+		if (!excludedPackages.isEmpty()) {
+			helper.getLog().warn("These packages were excluded from package cycle rule check: " + excludedPackages);
+		}
 		return new JDepend(PackageFilter.all()
 				.including(includedPackages)
 				.excluding(excludedPackages));

--- a/src/test/java/de/andrena/tools/nopackagecycles/NoPackageCyclesRuleTest.java
+++ b/src/test/java/de/andrena/tools/nopackagecycles/NoPackageCyclesRuleTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import jdepend.framework.JDepend;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -24,7 +25,7 @@ public class NoPackageCyclesRuleTest {
 
 	private class NoPackageCyclesRuleMock extends NoPackageCyclesRule {
 		@Override
-		protected JDepend createJDepend() {
+		protected JDepend createJDepend(EnforcerRuleHelper helper) {
 			return jdependMock;
 		}
 	}


### PR DESCRIPTION
Some libraries like bean-validation rely on strong package dependencies. For these exceptional cases, I would like to be able to exclude them from the analysis.